### PR TITLE
additional configurables and check cleanup

### DIFF
--- a/playbook.yml
+++ b/playbook.yml
@@ -16,7 +16,7 @@
 #
 
 - hosts: all
-  accelerate: true
+  accelerate: "{{accelerate}}"
   user: root
   roles:
-    - cis 
+    - cis

--- a/roles/cis/defaults/main.yml
+++ b/roles/cis/defaults/main.yml
@@ -2,7 +2,7 @@
 overwrite_pam: yes
 
 #Some companies may want to control these for their own reasons.
-overwrite_motd: yes
+overwrite_banners: yes
 
 #Should we disable system accounts?
 disable_system_accounts: yes

--- a/roles/cis/defaults/main.yml
+++ b/roles/cis/defaults/main.yml
@@ -1,3 +1,15 @@
+#Overwrite PAM files
+overwrite_pam: yes
+
+#Some companies may want to control these for their own reasons.
+overwrite_motd: yes
+
+#Should we disable system accounts?
+disable_system_accounts: yes
+
+#Should we enable selinux?
+enable_selinux: yes
+
 # Should we configure AIDE on the system? (CIS 1.3)
 # Options:
 #   yes: install and configure AIDE

--- a/roles/cis/tasks/section_01_level1.yml
+++ b/roles/cis/tasks/section_01_level1.yml
@@ -147,8 +147,11 @@
       - section1.2.1
 
   - name: 1.2.2 Verify Red Hat GPG key is installed (Scored)
-    command: gpg --quiet --with-fingerprint /etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release 
+    command: bash -c "gpg --quiet --with-fingerprint /etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release | grep '567E 347A D004 4ADE 55BA  8A5F 199E 2F91 FD43 1D51' | wc -l"
     when: ansible_distribution == "RedHat"
+    register: gpgkey
+    failed_when: "'0' in gpgkey.stdout"
+    changed_when: false
     tags:
       - scored
       - section1.2

--- a/roles/cis/tasks/section_01_level2.yml
+++ b/roles/cis/tasks/section_01_level2.yml
@@ -34,6 +34,7 @@
       state=present
       dest=/etc/modprobe.d/CIS.conf
       line="install cramfs /bin/true"
+	  create="yes"
     tags:
       - notscored
       - section1.1
@@ -44,6 +45,7 @@
       state=present
       dest=/etc/modprobe.d/CIS.conf
       line="install freevxfs /bin/true"
+	  create="yes"
     tags:
       - notscored
       - section1.1
@@ -54,6 +56,7 @@
       state=present
       dest=/etc/modprobe.d/CIS.conf
       line="install jffs2 /bin/true"
+	  create="yes"
     tags:
       - notscored
       - section1.1
@@ -64,6 +67,7 @@
       state=present
       dest=/etc/modprobe.d/CIS.conf
       line="install hfs /bin/true"
+	  create="yes"
     tags:
       - notscored
       - section1.1
@@ -74,6 +78,7 @@
       state=present
       dest=/etc/modprobe.d/CIS.conf
       line="install hfsplus /bin/true"
+	  create="yes"
     tags:
       - notscored
       - section1.1
@@ -84,6 +89,7 @@
       state=present
       dest=/etc/modprobe.d/CIS.conf
       line="install squashfs /bin/true"
+	  create="yes"
     tags:
       - notscored
       - section1.1
@@ -94,6 +100,7 @@
       state=present
       dest=/etc/modprobe.d/CIS.conf
       line="install udf /bin/true"
+	  create="yes"
     tags:
       - notscored
       - section1.1

--- a/roles/cis/tasks/section_01_level2.yml
+++ b/roles/cis/tasks/section_01_level2.yml
@@ -176,6 +176,7 @@
       state=absent
       dest=/etc/grub.conf
       line="selinux=0"
+    when: enable_selinux
     tags:
       - scored
       - section1.4
@@ -186,6 +187,7 @@
       state=absent
       dest=/etc/grub.conf
       line="enforcing=0"
+    when: enable_selinux
     tags:
       - scored
       - section1.4
@@ -195,6 +197,7 @@
     yum: >
       name=selinux-policy-targeted
       state=present
+    when: enable_selinux
     tags:
       - scored
       - section1.4
@@ -205,6 +208,7 @@
       state=enforcing
       policy=targeted
     ignore_errors: yes
+    when: enable_selinux
     tags:
       - scored
       - section1.4

--- a/roles/cis/tasks/section_05_level1.yml
+++ b/roles/cis/tasks/section_05_level1.yml
@@ -46,19 +46,29 @@
       - section5.1
       - section5.1.3
 
-  - name: 5.1.4 Create and Set Permissions on rsyslog Log Files (Scored)
-    file: >
-      path=/var/log/{{ item }}
-      state=touch
-      owner=root
-      group=wheel
-      mode=0640
+  - name: 5.1.4 Create and Set Permissions on rsyslog Log Files (Scored) (File Stat)
+    stat: path=/var/log/{{ item }}
+    register: rsyslog_files
     with_items:
         - messages
         - kern.log
         - daemon.log
         - syslog
         - unused.log
+    tags:
+      - scored
+      - section5.1
+      - section5.1.4
+
+  - name: 5.1.4 Create and Set Permissions on rsyslog Log Files (Scored)
+    file: >
+      path=/var/log/{{item.item}}
+      state=touch
+      owner=root
+      group=wheel
+      mode=0640
+    with_items: "{{rsyslog_files.results}}"
+    when: item.stat.exists == false or item.stat.mode != "0640" or item.stat.gr_name != "wheel" or item.stat.pw_name != "root" 
     tags:
       - scored
       - section5.1

--- a/roles/cis/tasks/section_06_level1.yml
+++ b/roles/cis/tasks/section_06_level1.yml
@@ -34,12 +34,21 @@
       - section6.1
       - section6.1.2
 
+  - name: 6.1.3 Check for /etc/anacrontab (Conditional)
+    stat: path=/etc/anacrontab
+    register: anacrontab_check
+    tags:
+      - scored
+      - section6.1
+      - section6.1.3
+
   - name: 6.1.3 Set User/Group Owner and Permission on /etc/anacrontab (Scored)
     file: >
       path=/etc/anacrontab
       owner=root
       group=root
       mode=0600
+    when: anacrontab_check.stat.exists
     tags:
       - scored
       - section6.1
@@ -351,6 +360,7 @@
       regexp="^Banner "
       line="Banner /etc/issue.net"
     notify: Reload sshd
+    when: overwrite_banners
     tags:
       - scored
       - section6.2
@@ -364,6 +374,7 @@
   - name: 6.3.1 Upgrade Password Hashing Algorithm to SHA-512 (Scored)
     shell: 'authconfig --test | grep hashing'
     register: password_hash_algorithm
+    changed_when: false
     always_run: yes
     tags:
       - scored
@@ -382,6 +393,7 @@
     copy: >
       src=etc/pam.d/system-auth
       dest=/etc/pam.d/system-auth
+    when: overwrite_pam
     tags:
       - scored
       - section6.3
@@ -393,6 +405,7 @@
     copy: >
       src=etc/pam.d/password-auth
       dest=/etc/pam.d/password-auth
+    when: overwrite_pam
     tags:
       - scored
       - section6.3
@@ -410,6 +423,7 @@
     copy: >
       src=etc/pam.d/su
       dest=/etc/pam.d/su
+    when: overwrite_pam
     tags:
       - scored
       - section6.5

--- a/roles/cis/tasks/section_07_level1.yml
+++ b/roles/cis/tasks/section_07_level1.yml
@@ -65,6 +65,7 @@
   - name: 7.2 Disable System Accounts (Scored)
     command: /usr/sbin/usermod -s /sbin/nologin {{ item }}
     with_items: enabled_system_accounts.stdout_lines
+    when: disable_system_accounts
     tags:
       - scored
       - section7.2
@@ -88,12 +89,20 @@
       - scored
       - section7.4
 
+  - name: Ensure that /etc/profile.d/cis.sh has correct owner, group and mode (Conditional)
+    stat: path=/etc/profile.d/cis.sh
+    register: cissh_check
+    tags:
+      - scored
+      - section7.4
+
   - name: Ensure that /etc/profile.d/cis.sh has correct owner, group and mode
     file: 
       path=/etc/profile.d/cis.sh 
       owner=root
       group=root
       mode=0644
+    when: cissh_check.stat.exists
     changed_when: false
     tags:
       - scored

--- a/roles/cis/tasks/section_08_level1.yml
+++ b/roles/cis/tasks/section_08_level1.yml
@@ -22,6 +22,7 @@
       - motd
       - issue
       - issue.net
+    when: overwrite_banners
     tags:
       - scored
       - section8.1
@@ -33,7 +34,7 @@
     changed_when: false
     with_items: 
       - stats.results
-    when: item.islnk is defined
+    when: item.islnk is defined and overwrite_banners
     tags:
       - scored
       - section8.1
@@ -45,7 +46,7 @@
     changed_when: false
     with_items: 
       - stats.results
-    when: item.islnk is defined
+    when: item.islnk is defined and overwrite_banners
     tags:
       - scored
       - section8.1
@@ -57,7 +58,7 @@
     changed_when: false
     with_items: 
       - stats.results
-    when: item.islnk is defined
+    when: item.islnk is defined and overwrite_banners
     tags:
       - scored
       - section8.1
@@ -70,6 +71,7 @@
       - motd
       - issue
       - issue.net
+    when: overwrite_banners
     tags:
       - scored
       - section8.1
@@ -84,6 +86,7 @@
       - motd
       - issue
       - issue.net
+    when: overwrite_banners
     tags:
       - scored
       - section8.1
@@ -97,6 +100,7 @@
       - motd
       - issue
       - issue.net 
+    when: overwrite_banners
     tags:
       - scored
       - section8.2


### PR DESCRIPTION
- Made some variable additions to make it more configurable depending on the use case, but didn't change the defaults, so you can expect the same changes to be executed.
- Cleaned up some of the checks so that they won't show as changed after the first run. 
- Up to you, but I changed Accelerate to a variable since, for my particular use case, the RHEL/Centos nodes could only use the out of the box repos, which does not include python-keyczar.package.
