### PR TITLE
Remove bare variables within with_ loops

### DIFF
--- a/roles/cis/tasks/section_01_level1.yml
+++ b/roles/cis/tasks/section_01_level1.yml
@@ -30,7 +30,7 @@
       fstype={{ item.fstype }}
       opts="nodev,nosuid,noexec"
     when: item.mount == "/tmp"
-    with_items: ansible_mounts
+    with_items: "{{ ansible_mounts }}"
     tags:
       - scored
       - section1.1
@@ -53,7 +53,7 @@
       fstype="none"
       opts="bind"
     when: item.mount == "/tmp"
-    with_items: ansible_mounts
+    with_items: "{{ ansible_mounts }}"
     tags:
       - scored
       - section1.1
@@ -88,7 +88,7 @@
       fstype={{ item.fstype }}
       opts="nodev"
     when: item.mount == "/home"
-    with_items: ansible_mounts
+    with_items: "{{ ansible_mounts }}"
     tags:
       - scored
       - section1.1

--- a/roles/cis/tasks/section_07_level1.yml
+++ b/roles/cis/tasks/section_07_level1.yml
@@ -64,7 +64,7 @@
 
   - name: 7.2 Disable System Accounts (Scored)
     command: /usr/sbin/usermod -s /sbin/nologin {{ item }}
-    with_items: enabled_system_accounts.stdout_lines
+    with_items: "{{ enabled_system_accounts.stdout_lines }}"
     tags:
       - scored
       - section7.2

--- a/roles/cis/tasks/section_08_level1.yml
+++ b/roles/cis/tasks/section_08_level1.yml
@@ -32,7 +32,7 @@
       state=absent
     changed_when: false
     with_items: 
-      - stats.results
+      - "{{ stats.results }}"
     when: item.islnk is defined
     tags:
       - scored
@@ -44,7 +44,7 @@
       state=absent
     changed_when: false
     with_items: 
-      - stats.results
+      - "{{ stats.results }}"
     when: item.islnk is defined
     tags:
       - scored
@@ -56,7 +56,7 @@
       state=absent
     changed_when: false
     with_items: 
-      - stats.results
+      - "{{ stats.results }}"
     when: item.islnk is defined
     tags:
       - scored


### PR DESCRIPTION
Using bare variables—e.g. `ansible_mounts` within `with_` loops is deprecated from ansible 2.0 onwards. Therefore, you should use the full variable syntax e.g. `"{{ ansible_mounts }}"`

Ansible 2.0 porting guide: https://docs.ansible.com/ansible/porting_guide_2.0.html

Fixes #31 
